### PR TITLE
added posibility to get access code

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ $ npm i react-native-linkedin --save
 | wrapperStyle | ViewPropTypes.style | optional | | Customize wrapper style |
 | closeStyle | ViewPropTypes.style | optional | | Customize close style |
 | animationType | Modal.propTypes.animationType | optional | `fade` | Customize animationType style: 'none', 'slide' or 'fade' |
+| shouldGetAccessToken | bool | optional | `true` | Set to false to receive the 'authorization code' rather then the 'access token'
 
 ### Example
 ```JavaScript

--- a/index.js
+++ b/index.js
@@ -149,15 +149,19 @@ export const onLoadStart = async (
     onError(transformError(err))
   } else {
     const { code, state } = getCodeAndStateFromUrl(url)
-    if (state !== authState) {
-      onError({
-        type: 'state_not_match',
-        message: `state is not the same ${state}`,
-      })
+    if (!shouldGetAccessToken) {
+      onSuccess(code);
     } else {
-      const token: LinkedInToken | {} = await getAccessToken(code)
-      onSuccess(token)
-    }
+        if (state !== authState) {
+          onError({
+            type: 'state_not_match',
+            message: `state is not the same ${state}`,
+          })
+        } else {
+          const token: LinkedInToken | {} = await getAccessToken(code)
+          onSuccess(token)
+        }
+      }
   }
 }
 
@@ -208,6 +212,7 @@ export default class LinkedInModal extends React.Component {
     wrapperStyle: ViewPropTypes.style,
     closeStyle: ViewPropTypes.style,
     animationType: Modal.propTypes.animationType,
+    shouldGetAccessToken: PropTypes.bool
   }
   static defaultProps = {
     onError: logError,
@@ -217,6 +222,7 @@ export default class LinkedInModal extends React.Component {
     containerStyle: StyleSheet.create({}),
     wrapperStyle: StyleSheet.create({}),
     closeStyle: StyleSheet.create({}),
+    shouldGetAccessToken: true
   }
   state: State = {
     raceCondition: false,
@@ -236,7 +242,7 @@ export default class LinkedInModal extends React.Component {
 
   onLoadStart = async ({ nativeEvent: { url } }: Object) => {
     const { raceCondition } = this.state
-    const { redirectUri, onError } = this.props
+    const { redirectUri, onError, shouldGetAccessToken } = this.props
 
     if (url.includes(redirectUri) && !raceCondition) {
       const { onSignIn, onSuccess } = this.props
@@ -245,6 +251,7 @@ export default class LinkedInModal extends React.Component {
       if (onSignIn) onSignIn()
       await onLoadStart(
         url,
+        shouldGetAccessToken,
         authState,
         onSuccess,
         onError,


### PR DESCRIPTION
Added a new property to LinkedinModal, 'shouldGetAccessToken'. It defaults to true, so not setting it will keep current modal behaviour of retrieving the access token. If set to false, will retrieve the authorization code, and no longer request the token. 